### PR TITLE
Add public header and user role hooks, update org card for public view

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -420,7 +420,7 @@ export default function AdminOrgs() {
 
   // Update the AdminHeader to use the new handler
   return (
-    <div className="min-h-screen bg-black text-white relative overflow-hidden">
+    <div className="min-h-screen bg-black text-white relative">
       {/* Stained glass background overlay */}
       <div
         className="fixed inset-0 opacity-30 pointer-events-none"

--- a/app/components/Icons/index.tsx
+++ b/app/components/Icons/index.tsx
@@ -1,7 +1,7 @@
 import {
   ClockIcon, CheckCircleIcon, XCircleIcon, PencilSimpleIcon, ChartBarIcon, FloppyDiskIcon, XIcon,
   GlobeIcon, LightningIcon, CloudIcon, MapPinIcon, TrendUpIcon, CalendarIcon,
-  SortAscendingIcon, SortDescendingIcon,FunnelIcon, MagnifyingGlassIcon, PlusIcon, SignOutIcon, HashIcon, ListChecksIcon, ChatCircleIcon, LightbulbIcon,
+  SortAscendingIcon, SortDescendingIcon,FunnelIcon, MagnifyingGlassIcon, PlusIcon, SignInIcon, SignOutIcon, HashIcon, ListChecksIcon, ChatCircleIcon, LightbulbIcon,
   EnvelopeIcon, UsersIcon, TrophyIcon, MegaphoneIcon,
 } from '@phosphor-icons/react';
 
@@ -16,6 +16,7 @@ export const ClimateIcons = {
   cancel: <XIcon className="w-4 h-4" weight="duotone" />,
   plus: <PlusIcon className="w-4 h-4" weight="duotone" />,
   search: <MagnifyingGlassIcon className="w-4 h-4" weight="duotone" />,
+  login: <SignInIcon className="w-4 h-4" weight="duotone" />,
   logout: <SignOutIcon className="w-4 h-4" weight="duotone" />,
   total: <HashIcon className="w-4 h-4" weight="duotone" />,
   guide: <ListChecksIcon className="w-4 h-4" weight="duotone" />,

--- a/app/components/PublicHeader/index.tsx
+++ b/app/components/PublicHeader/index.tsx
@@ -34,8 +34,6 @@ interface PublicHeaderProps {
   onSortChange: (options: SortOptions) => void;
   filterOptions: FilterOptions;
   onFilterOptionsChange: (options: FilterOptions) => void;
-  filteredCount: number;
-  totalOrgs: number;
   isSearching?: boolean;
 }
 
@@ -47,8 +45,6 @@ export function PublicHeader({
   onSortChange,
   filterOptions,
   onFilterOptionsChange,
-  filteredCount,
-  totalOrgs,
   isSearching = false
 }: PublicHeaderProps) {
   const router = useRouter();

--- a/app/components/PublicHeader/index.tsx
+++ b/app/components/PublicHeader/index.tsx
@@ -3,19 +3,17 @@ import { CustomDropdown } from '../CustomDropdown';
 import { ClimateIcons } from '../Icons';
 import { 
   getContinentOptions, 
-  getScoreRangeOptions, 
   getSortFieldOptions 
 } from '../../utils/selectOptions';
 import { useRouter } from 'next/navigation';
+import { useUser } from '../../hooks/useUser';
 
 interface FilterOptions {
-  status: 'all' | 'pending' | 'approved' | 'rejected';
   continent: string;
-  scoreRange: string;
 }
 
 interface SortOptions {
-  field: 'name' | 'score' | 'status' | 'country' | 'recent' | 'website';
+  field: 'name' | 'country' | 'recent' | 'website';
   direction: 'asc' | 'desc';
 }
 
@@ -27,19 +25,7 @@ interface MetadataProgress {
   isActive?: boolean;
 }
 
-interface AdminHeaderProps {
-  filter: 'all' | 'pending' | 'approved' | 'rejected';
-  onFilterChange: (filter: 'all' | 'pending' | 'approved' | 'rejected') => void;
-  showRejected: boolean;
-  onToggleRejected: () => void;
-  onAddNew: () => void;
-  onLogout: () => void;
-  orgCounts: {
-    all: number;
-    pending: number;
-    approved: number;
-    rejected: number;
-  };
+interface PublicHeaderProps {
   isLoading?: boolean;
   metadataProgress?: MetadataProgress;
   searchQuery: string;
@@ -53,12 +39,7 @@ interface AdminHeaderProps {
   isSearching?: boolean;
 }
 
-export function AdminHeader({
-  filter,
-  onFilterChange,
-  onAddNew,
-  onLogout,
-  orgCounts,
+export function PublicHeader({
   metadataProgress,
   searchQuery,
   onSearchChange,
@@ -69,34 +50,25 @@ export function AdminHeader({
   filteredCount,
   totalOrgs,
   isSearching = false
-}: AdminHeaderProps) {
+}: PublicHeaderProps) {
   const router = useRouter();
+  const { user, role, logout } = useUser(); // role: 'admin' | 'artist' | 'org' | undefined
 
   const clearAllFilters = () => {
     onSearchChange('');
     onFilterOptionsChange({
-      status: 'all',
       continent: 'all',
-      scoreRange: 'all',
     });
     onSortChange({ field: 'name', direction: 'asc' });
-    onFilterChange('all');
   };
 
-  const hasActiveFilters = searchQuery || 
-    filterOptions.continent !== 'all' || 
-    filterOptions.scoreRange !== 'all' ||
-    filter !== 'all';
+  const hasActiveFilters = !!searchQuery || filterOptions.continent !== 'all';
 
   // Helper function to get appropriate sort toggle label
   const getSortToggleLabel = (field: string, direction: 'asc' | 'desc') => {
     switch (field) {
       case 'name':
         return direction === 'asc' ? 'A-Z' : 'Z-A';
-      case 'score':
-        return direction === 'asc' ? 'Low-High' : 'High-Low';
-      case 'status':
-        return direction === 'asc' ? 'P-A-R' : 'R-A-P'; // Pending-Approved-Rejected
       case 'country':
         return direction === 'asc' ? 'A-Z' : 'Z-A';
       case 'recent':
@@ -119,31 +91,39 @@ export function AdminHeader({
               Climate Organization Dashboard
             </h1>
           </div>
-          
-          <div className="flex items-center gap-3 flex-wrap">
-            <button
-              onClick={onAddNew}
-              className="btn-glass btn-glass-green px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 hover:shadow-glow-green transition-all duration-200"
-            >
-              {ClimateIcons.plus}
-              <span>Add Organization</span>
-            </button>
-
-            <button
-              onClick={() => router.push('/')}
-              className="btn-glass text-gray-300 px-3 py-2 rounded-lg text-sm font-medium hover:text-white transition-colors flex items-center gap-2"
-            >
-              {ClimateIcons.climate}
-              <span>Public Page</span>
-            </button>
-
-            <button
-              onClick={onLogout}
-              className="btn-glass text-gray-300 px-3 py-2 rounded-lg text-sm font-medium hover:text-white transition-colors flex items-center gap-2"
-            >
-              {ClimateIcons.logout}
-              <span>Logout</span>
-            </button>
+          <div className="flex items-center gap-3">
+            {user ? (
+              <>
+                <button
+                  onClick={() => {
+                    if (role === 'artist') router.push('/artist');
+                    else if (role === 'admin') router.push('/admin');
+                    else if (role === 'org') router.push('/org');
+                  }}
+                  className="btn-glass px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2"
+                >
+                  {role === 'artist' ? 'Artist' : role === 'admin' ? 'Admin' : 'Org'} Dashboard
+                </button>
+                <button
+                  onClick={() => {
+                    logout();
+                    router.push('/');
+                  }}
+                  className="btn-glass text-gray-300 px-3 py-2 rounded-lg text-sm font-medium hover:text-white transition-colors flex items-center gap-2"
+                >
+                  {ClimateIcons.logout}
+                  <span>Logout</span>
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={() => router.push('/login')}
+                className="btn-glass px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2"
+              >
+                {ClimateIcons.login}
+                <span>Login</span>
+              </button>
+            )}
           </div>
         </div>
 
@@ -203,65 +183,6 @@ export function AdminHeader({
         <div className="flex flex-wrap items-center justify-between gap-4 text-sm">
           {/* Left: Status Filter Buttons */}
           <div className="flex items-center gap-3 flex-wrap">
-            {/* Status Filter Buttons */}
-            <button
-              onClick={() => onFilterChange('approved')}
-              onMouseDown={(e) => e.preventDefault()} // Prevent focus auto-scroll
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-all duration-200 ${
-                filter === 'approved' 
-                  ? 'bg-green-500/20 text-green-300 border border-green-500/30' 
-                  : 'hover:bg-green-500/10 hover:text-green-300'
-              }`}
-            >
-              {ClimateIcons.approved}
-              <span>Approved: <span className="font-medium">{orgCounts.approved}</span></span>
-            </button>
-            
-            <button
-              onClick={() => onFilterChange('pending')}
-              onMouseDown={(e) => e.preventDefault()} // Prevent focus auto-scroll
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-all duration-200 ${
-                filter === 'pending' 
-                  ? 'bg-yellow-500/20 text-yellow-300 border border-yellow-500/30' 
-                  : 'hover:bg-yellow-500/10 hover:text-yellow-300'
-              }`}
-            >
-              {ClimateIcons.pending}
-              <span>Pending: <span className="font-medium">{orgCounts.pending}</span></span>
-            </button>
-            
-            <button
-              onClick={() => onFilterChange('rejected')}
-              onMouseDown={(e) => e.preventDefault()} // Prevent focus auto-scroll
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-all duration-200 ${
-                filter === 'rejected' 
-                  ? 'bg-red-500/20 text-red-300 border border-red-500/30' 
-                  : 'hover:bg-red-500/10 hover:text-red-300'
-              }`}
-            >
-              {ClimateIcons.rejected}
-              <span>Rejected: <span className="font-medium">{orgCounts.rejected}</span></span>
-            </button>
-
-            {/* All Organizations Button with Count */}
-            <button
-              onClick={() => onFilterChange('all')}
-              onMouseDown={(e) => e.preventDefault()} // Prevent focus auto-scroll
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-all duration-200 ${
-                filter === 'all' 
-                  ? 'bg-blue-500/20 text-blue-300 border border-blue-500/30' 
-                  : 'hover:bg-blue-500/10 hover:text-blue-300'
-              }`}
-            >
-              {ClimateIcons.total}
-              <span>
-                All: <span className="font-medium">{orgCounts.all}</span>
-                {filteredCount !== totalOrgs && (
-                  <span className="text-gray-400 ml-1">({filteredCount} shown)</span>
-                )}
-              </span>
-            </button>
-
             {/* Clear Filters Button */}
             {hasActiveFilters && (
               <button
@@ -292,28 +213,12 @@ export function AdminHeader({
               />
             </div>
 
-            {/* Score Range Filter */}
-            <div className="min-w-[160px]">
-              <CustomDropdown
-                options={getScoreRangeOptions()}
-                value={filterOptions.scoreRange}
-                onChange={(value) => onFilterOptionsChange({
-                  ...filterOptions,
-                  scoreRange: value
-                })}
-                placeholder="Filter by score..."
-                colorCoded={true}
-                className="w-full"
-                portal={false}
-              />
-            </div>
-
             {/* Sort Options with Direction Toggle */}
             <div className="flex gap-2">
               {/* Sort Field Dropdown */}
               <div className="min-w-[140px]">
                 <CustomDropdown
-                  options={getSortFieldOptions()}
+                  options={getSortFieldOptions().filter(opt => opt.value !== 'score' && opt.value !== 'status')}
                   value={sortOptions.field}
                   onChange={(value) => onSortChange({
                     ...sortOptions,
@@ -363,4 +268,4 @@ export function AdminHeader({
   );
 }
 
-export default AdminHeader;
+export default PublicHeader;

--- a/app/globals.css
+++ b/app/globals.css
@@ -299,9 +299,9 @@ body {
 
 
 /* ============================================
-   ADMIN HEADER
+   HEADER
    ============================================ */
-.admin-header {
+.header {
   position: sticky;
   top: 0;
   z-index: 9999;
@@ -314,13 +314,13 @@ body {
   overflow: visible;
 }
 
-.admin-header>div {
+.header > div {
   position: relative;
   z-index: 10000;
   overflow: visible;
 }
 
-.admin-header .dropdown-glass {
+.header .dropdown-glass {
   position: absolute;
   z-index: 99999;
   top: 100%;
@@ -329,7 +329,7 @@ body {
   margin-top: 4px;
 }
 
-.admin-header [class*="relative"] {
+.header [class*="relative"] {
   overflow: visible;
 }
 

--- a/app/hooks/useUser.ts
+++ b/app/hooks/useUser.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { createClient } from '../utils/supabase/client';
+
+type Role = 'admin' | 'artist' | 'org' | undefined;
+
+interface User {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+export function useUser() {
+  const supabase = createClient();
+  const [user, setUser] = useState<User | null>(null);
+  const [role, setRole] = useState<Role>(undefined);
+
+  useEffect(() => {
+    const getUserAndRole = async () => {
+      const { data, error } = await supabase.auth.getUser();
+      if (data?.user) {
+        setUser({
+          id: data.user.id,
+          email: data.user.email ?? '',
+          name: data.user.user_metadata?.name ?? '',
+        });
+
+        // Query the user_roles table for this user's role
+        const { data: roleData, error: roleError } = await supabase
+          .from('user_roles')
+          .select('role')
+          .eq('user_id', data.user.id)
+          .single();
+
+        if (roleData?.role) {
+          setRole(roleData.role as Role);
+        } else {
+          setRole(undefined);
+        }
+      } else {
+        setUser(null);
+        setRole(undefined);
+      }
+    };
+
+    getUserAndRole();
+
+    // Listen for auth state changes
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        setUser({
+          id: session.user.id,
+          email: session.user.email ?? '',
+          name: session.user.user_metadata?.name ?? '',
+        });
+        // Fetch role again on login
+        supabase
+          .from('user_roles')
+          .select('role')
+          .eq('user_id', session.user.id)
+          .single()
+          .then(({ data: roleData }) => {
+            setRole(roleData?.role as Role || undefined);
+          });
+      } else {
+        setUser(null);
+        setRole(undefined);
+      }
+    });
+
+    return () => {
+      listener?.subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  const logout = async () => {
+    await supabase.auth.signOut();
+    setUser(null);
+    setRole(undefined);
+  };
+
+  return { user, role, logout };
+}

--- a/app/hooks/useUser.ts
+++ b/app/hooks/useUser.ts
@@ -16,7 +16,7 @@ export function useUser() {
 
   useEffect(() => {
     const getUserAndRole = async () => {
-      const { data, error } = await supabase.auth.getUser();
+      const { data } = await supabase.auth.getUser();
       if (data?.user) {
         setUser({
           id: data.user.id,
@@ -25,7 +25,7 @@ export function useUser() {
         });
 
         // Query the user_roles table for this user's role
-        const { data: roleData, error: roleError } = await supabase
+        const { data: roleData } = await supabase
           .from('user_roles')
           .select('role')
           .eq('user_id', data.user.id)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useOrganizations } from './hooks/useOrganizations';
 import { useAutoWebsiteMetadata } from './hooks/useWebsiteMetadata';
 import OrganizationCard from './components/OrganizationCard';
@@ -150,8 +150,6 @@ export default function HomePage() {
         onSortChange={setSortOptions}
         filterOptions={filterOptions}
         onFilterOptionsChange={setFilterOptions}
-        filteredCount={filteredOrgs.length}
-        totalOrgs={orgs.length}
         isSearching={isSearching}
       />
       <main className="max-w-screen-xl mx-auto px-4 sm:px-6 py-8">
@@ -170,7 +168,7 @@ export default function HomePage() {
                 savingScores=""
                 onExpand={() => {}}
                 onEdit={() => {}}
-                onSave={async (_orgId: string, _data: Partial<any>) => false}
+                onSave={async () => false}
                 onCancel={() => {}}
                 onStatusUpdate={() => {}}
                 isPublic={true}

--- a/app/utils/supabase/middleware.ts
+++ b/app/utils/supabase/middleware.ts
@@ -39,10 +39,8 @@ export async function updateSession(request: NextRequest) {
 
   if (
     !user &&
-    !request.nextUrl.pathname.startsWith('/login') &&
-    !request.nextUrl.pathname.startsWith('/auth')
+    !['/', '/login', '/auth'].includes(request.nextUrl.pathname)
   ) {
-    // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone()
     url.pathname = '/login'
     return NextResponse.redirect(url)


### PR DESCRIPTION
Introduces a new PublicHeader component for the public dashboard, and a useUser hook for user/role management. Updates OrganizationCard to support a public view (isPublic), hiding admin-only controls and adjusting displayed info. Refactors useOrganizations to use a public org view for non-admins and adds forcePublic option. Updates global styles to generalize admin-header to header. Adds login/logout and dashboard navigation to the public header, and improves dropdown portal handling.